### PR TITLE
fix: 회원 가입 이메일 인증 추가

### DIFF
--- a/lib/present/login_screen/login_screen.dart
+++ b/lib/present/login_screen/login_screen.dart
@@ -23,7 +23,7 @@ class _LoginScreenState extends State<LoginScreen> {
         email: _idController.text,
         password: _pwController.text,
       );
-      // Todo: _auth.currentUser.uid
+      // Todo: _auth.currentUser.uidㅁ
       // Todo: GoRouterRedirect
 
       // 로그인에 성공하면 CheckScreen으로 이동

--- a/lib/present/login_screen/sign_up_screen.dart
+++ b/lib/present/login_screen/sign_up_screen.dart
@@ -23,8 +23,13 @@ class _SignUpScreenState extends State<SignUpScreen> {
         email: _idController.text,
         password: _pwController.text,
       );
-      GoRouter.of(context).go(
-        '/login',
+      await userCredential.user!.sendEmailVerification();
+
+      // 회원 가입 완료 메시지 출력
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('이메일 확인 후 로그인하세요.'),
+        ),
       );
     } on FirebaseAuthException catch (e) {
       if (e.code == 'weak-password') {
@@ -86,12 +91,24 @@ class _SignUpScreenState extends State<SignUpScreen> {
                 ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: ElevatedButton(
-                onPressed: () => signUpWithFirebase(context),
-                child: Text('회원 가입'),
-              ),
+            Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: ElevatedButton(
+                    onPressed: () => signUpWithFirebase(context),
+                    child: Text('회원 가입'),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    GoRouter.of(context).go(
+                      '/login',
+                    );
+                  },
+                  child: Text('확인'),
+                ),
+              ],
             ),
           ],
         ),


### PR DESCRIPTION
firebase에서 지원하는 메소드 sendEmailVerification() 를 사용하여 이메일 확인후 회원가입이 가능하게 로직 변경 하지만 mock-data에서는 이메일이 발송이 안되는 것을 확인.

출결 체크기 어플에서는 로그인만 있고 회원 가입은 굳이 필요하지 않은 기능.
테스트용.